### PR TITLE
In record_versions, left-join old versions into new versions to avoid…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal internal infrastructure
   package to automate contribution reviews and populate universes.
-Version: 0.1.1
+Version: 0.1.2
 License: MIT + file LICENSE
 URL: https://github.com/r-multiverse/multiverse.internals
 BugReports: https://github.com/r-multiverse/multiverse.internals/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# multiverse.internals 0.1.2
+
+* In `record_versions()`, left-join old versions into new versions to avoid spamming `versions.json` with an unbounded list of renamed or abandoned packages.
+
 # multiverse.internals 0.1.1
 
 * Rename internal functions and arguments.

--- a/R/record_versions.R
+++ b/R/record_versions.R
@@ -78,7 +78,13 @@ read_versions_previous <- function(manifest) {
 }
 
 update_version_manifest <- function(current, previous) {
-  new <- merge(x = current, y = previous, all = TRUE)
+  new <- merge(
+    x = current,
+    y = previous,
+    by = "package",
+    all.x = TRUE,
+    all.y = FALSE
+  )
   incremented <- manifest_compare_versions(manifest = new) == 1L
   new$version_highest[incremented] <- new$version_current[incremented]
   new$hash_highest[incremented] <- new$hash_current[incremented]


### PR DESCRIPTION
… spamming versions.json with an unbounded list of renamed or abandoned packages.