### PR TITLE
Require that commits come from the GitHub web UI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal internal infrastructure
   package to automate contribution reviews and populate universes.
-Version: 0.2.7
+Version: 0.2.8
 License: MIT + file LICENSE
 URL: https://github.com/r-multiverse/multiverse.internals
 BugReports: https://github.com/r-multiverse/multiverse.internals/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# multiverse.internals 0.2.8
+
+* Only merge contributions created through the web interface.
+
 # multiverse.internals 0.2.7
 
 * Exclude superfluous fields from `update_production()` `packages.json`.

--- a/R/review_pull_requests.R
+++ b/R/review_pull_requests.R
@@ -9,8 +9,8 @@ review_pull_requests <- function(
   owner = "r-multiverse",
   repo = "contributions"
 ) {
-  assert_character_scalar(owner)
-  assert_character_scalar(repo)
+  assert_character_scalar(owner, "owner must be a character string")
+  assert_character_scalar(repo, "repo must be a character string")
   message("Listing pull requests...")
   pull_requests <- gh::gh(
     "/repos/:owner/:repo/pulls",


### PR DESCRIPTION
In this PR, the bot only merges contributions created through the web UI as demonstrated in the video at https://r-multiverse.org/contributors.html. Commits like https://github.com/r-multiverse/contributions/pull/194 created from the command line are flagged for manual review. I think this solves most of https://github.com/r-multiverse/help/discussions/63.

To check if the commit came from the GitHub web UI, we check that the committer name is "GitHub", the email is noreply@github.com, and the commit is verified.