### PR TITLE
assert_package_description() checks for Authors@R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal infrastructure package to
   automate contribution reviews and populate universes.
-Version: 0.3.0.9000
+Version: 0.3.1
 License: MIT + file LICENSE
 URL:
   https://r-multiverse.org/multiverse.internals/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# multiverse.internals 0.3.1
+
+* Add extra checks for `Authors@R` in `assert_parsed_description()`.
+
 # multiverse.internals 0.3.0.9000 (development)
 
 * Test `update_topics()` on an empty topic.

--- a/R/assert_package_description.R
+++ b/R/assert_package_description.R
@@ -90,6 +90,22 @@ assert_parsed_description <- function(name, description) {
       )
     )
   }
+  authors_r <- try(
+    eval(parse(text = description$get("Authors@R"))),
+    silent = TRUE
+  )
+  if (inherits(authors_r, "try-error")) {
+    return("Could not parse the Authors@R field of the package DESCRIPTION.")
+  }
+  if (any(grepl("first[ \t]*last", tolower(authors_r)))) {
+    return(
+      paste(
+        "'First Last' is not a serious author name.",
+        "Packages must correctly attribute ownership and authorship in",
+        "the DESCRIPTION and license."
+      )
+    )
+  }
   license <- description$get("License")
   if (!(license %in% trusted_licenses)) {
     return(

--- a/tests/testthat/test-assert_package_description.R
+++ b/tests/testthat/test-assert_package_description.R
@@ -137,3 +137,56 @@ test_that("assert_license_local() with empty fields", {
   )
   expect_true(grepl("key-value pairs with empty values", out))
 })
+
+test_that("assert_parsed_description() detects malformed Authors@R", {
+  text <- paste(
+    c(
+      "Package: x",
+      "Title: What the Package Does (One Line, Title Case)",
+      "Version: 0.0.0.9000",
+      "Authors@R: c(",
+      "  person(\"First\", \"Last\", ,",
+      "   \"first.last@example.com\", role = c(\"aut\", \"cre\"),",
+      "   comment = c(ORCID = \"YOUR-ORCID-ID\")),",
+      "   person(\"First\", \"Last\", ,",
+      "  \"first.last@example.com\", role = c(\"aut\", \"cre\"),",
+      "   comment = c(ORCID = \"YOUR-ORCID-ID\"))",
+      "Description: What the package does (one paragraph).",
+      "License: GPL-3"),
+    collapse = "\n"
+  )
+  x <- desc::description$new(text = text)
+  expect_true(
+    grepl(
+      "Could not parse the Authors@R field of the package DESCRIPTION",
+      assert_parsed_description("x", x),
+      fixed = TRUE
+    )
+  )
+})
+
+test_that("assert_parsed_description() detects usethis default Authors@R", {
+  text <- paste(
+    c(
+      "Package: x",
+      "Title: What the Package Does (One Line, Title Case)",
+      "Version: 0.0.0.9000",
+      "Authors@R: c(",
+      "  person(\"First\", \"Last\", ,",
+      "   \"first.last@example.com\", role = c(\"aut\", \"cre\"),",
+      "   comment = c(ORCID = \"YOUR-ORCID-ID\")),",
+      "   person(\"First\", \"Last\", ,",
+      "  \"first.last@example.com\", role = c(\"aut\", \"cre\"),",
+      "   comment = c(ORCID = \"YOUR-ORCID-ID\")))",
+      "Description: What the package does (one paragraph).",
+      "License: GPL-3"),
+    collapse = "\n"
+  )
+  x <- desc::description$new(text = text)
+  expect_true(
+    grepl(
+      "not a serious author name",
+      assert_parsed_description("x", x)
+    )
+  )
+})


### PR DESCRIPTION
Checks that `Authors@R` is not malformed and is not the cheap `usethis::create_package()` default.