### PR TITLE
Staging fixes

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,5 @@
 linters: linters_with_defaults(
-  cyclocomp_linter = NULL,
+  return_linter = NULL,
   infix_spaces_linter = NULL,
   object_length_linter = NULL,
   object_name_linter = NULL,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal infrastructure package to
   automate contribution reviews and populate universes.
-Version: 0.3.5
+Version: 0.3.6
 License: MIT + file LICENSE
 URL:
   https://r-multiverse.org/multiverse.internals/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # multiverse.internals 0.3.6
 
 * Detect source failures as issues.
+* Flag R-multiverse packages whose CRAN versions from the day of the Staging freeze are higher than the current versions in R-multiverse.
+* Use the whole R version in `propose_snapshot()` so downstream automation can grep the snapshot URL for the version instead of needing to install R and the `rversions` package.
 
 # multiverse.internals 0.3.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# multiverse.internals 0.3.6
+
+* Detect source failures as issues.
+
 # multiverse.internals 0.3.5
 
 * Depend on R >= 4.4.0 for the base coalescing operator `%||%`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Detect source failures as issues.
 * Flag R-multiverse packages whose CRAN versions from the day of the Staging freeze are higher than the current versions in R-multiverse.
 * Use the whole R version in `propose_snapshot()` so downstream automation can grep the snapshot URL for the version instead of needing to install R and the `rversions` package.
+* Write `config.json` in Staging to select the CRAN snapshot from the start of the freeze.
 
 # multiverse.internals 0.3.5
 

--- a/R/interpret_status.R
+++ b/R/interpret_status.R
@@ -38,7 +38,7 @@ interpret_title <- function(issue, package) {
   if (is.character(issue$remote_hash)) {
     title <- paste(title, "remote hash", issue$remote_hash)
   }
-  paste0(title, " since ", issue$date, ".<br><br>")
+  paste0(title, " (as of ", issue$date, ").<br><br>")
 }
 
 interpret_advisories <- function(issue) {
@@ -161,32 +161,33 @@ interpret_versions <- function(issue) {
 
 interpert_version_conflicts <- function(issues) {
   out <- character(0L)
-  if (!is.null(issues$cran)) {
+  if (!is.null(issues$descriptions$cran)) {
     out <- paste(
       out,
       "On CRAN, this package had version",
-      issues$cran,
-      "at the beginning of the most recent R-multiverse Staging period.",
+      issues$descriptions$cran,
+      "during the first day of the most recent R-multiverse Staging period.",
       "The version on R-multiverse is lower,",
       "which causes install.packages() to prefer CRAN.",
       "If you have not already done so, please ensure the latest",
       "GitHub/GitLab release has a suitably recent version",
-      "in the DESCRIPTION file."
+      "in the DESCRIPTION file.<br><br>"
     )
   }
-  if (!is.null(issues$bioconductor)) {
+  if (!is.null(issues$descriptions$bioconductor)) {
     out <- paste(
       out,
       "On Bioconductor, this package had version",
-      issues$bioconductor,
-      "at the beginning of the most recent R-multiverse Staging period.",
+      issues$descriptions$bioconductor,
+      "during the first day of the most recent R-multiverse Staging period.",
       "The version on R-multiverse is lower,",
       "which causes install.packages() to prefer Bioconductor.",
       "If you have not already done so, please ensure the latest",
       "GitHub/GitLab release has a suitably recent version",
-      "in the DESCRIPTION file."
+      "in the DESCRIPTION file.<br><br>"
     )
   }
+  trimws(out)
 }
 
 yaml_html <- function(x) {

--- a/R/interpret_status.R
+++ b/R/interpret_status.R
@@ -174,19 +174,6 @@ interpert_version_conflicts <- function(issues) {
       "in the DESCRIPTION file.<br><br>"
     )
   }
-  if (!is.null(issues$descriptions$bioconductor)) {
-    out <- paste(
-      out,
-      "On Bioconductor, this package had version",
-      issues$descriptions$bioconductor,
-      "during the first day of the most recent R-multiverse Staging period.",
-      "The version on R-multiverse is lower,",
-      "which causes install.packages() to prefer Bioconductor.",
-      "If you have not already done so, please ensure the latest",
-      "GitHub/GitLab release has a suitably recent version",
-      "in the DESCRIPTION file.<br><br>"
-    )
-  }
   trimws(out)
 }
 

--- a/R/interpret_status.R
+++ b/R/interpret_status.R
@@ -19,6 +19,7 @@ interpret_status <- function(package, issues) {
       interpret_checks(issue),
       interpret_dependencies(issue, package),
       interpret_remotes(issue),
+      interpert_version_conflicts(issue),
       interpret_versions(issue)
     ),
     collapse = ""
@@ -31,7 +32,7 @@ interpret_title <- function(issue, package) {
     "R-multiverse found issues with package ",
     package
   )
-  if (is.character(issue$versions)) {
+  if (is.character(issue$version)) {
     title <- paste(title, "version", issue$version)
   }
   if (is.character(issue$remote_hash)) {
@@ -156,6 +157,36 @@ interpret_versions <- function(issue) {
     "and the latest remote hash of each:<br>",
     as.character(yaml_html(versions))
   )
+}
+
+interpert_version_conflicts <- function(issues) {
+  out <- character(0L)
+  if (!is.null(issues$cran)) {
+    out <- paste(
+      out,
+      "On CRAN, this package had version",
+      issues$cran,
+      "at the beginning of the most recent R-multiverse Staging period.",
+      "The version on R-multiverse is lower,",
+      "which causes install.packages() to prefer CRAN.",
+      "If you have not already done so, please ensure the latest",
+      "GitHub/GitLab release has a suitably recent version",
+      "in the DESCRIPTION file."
+    )
+  }
+  if (!is.null(issues$bioconductor)) {
+    out <- paste(
+      out,
+      "On Bioconductor, this package had version",
+      issues$bioconductor,
+      "at the beginning of the most recent R-multiverse Staging period.",
+      "The version on R-multiverse is lower,",
+      "which causes install.packages() to prefer Bioconductor.",
+      "If you have not already done so, please ensure the latest",
+      "GitHub/GitLab release has a suitably recent version",
+      "in the DESCRIPTION file."
+    )
+  }
 }
 
 yaml_html <- function(x) {

--- a/R/issues_descriptions.R
+++ b/R/issues_descriptions.R
@@ -9,7 +9,7 @@
 #'   2. Licenses that cannot be verified as free and open-source.
 #'   3. The presence of a `"Remotes"` field.
 #'   4. A lower version number on R-multiverse than on CRAN,
-#'     if the package is also published on the latter.
+#'     if the package is also published there.
 #' @inheritSection record_issues Package issues
 #' @return A named list of information about packages which do not comply
 #'   with `DESCRPTION` checks. Each name is a package name,

--- a/R/issues_descriptions.R
+++ b/R/issues_descriptions.R
@@ -8,6 +8,8 @@
 #'     <https://github.com/RConsortium/r-advisory-database>.
 #'   2. Licenses that cannot be verified as free and open-source.
 #'   3. The presence of a `"Remotes"` field.
+#'   4. A lower version number on R-multiverse than on CRAN or Bioconductor,
+#'     if the package is on either of these other package repositories.
 #' @inheritSection record_issues Package issues
 #' @return A named list of information about packages which do not comply
 #'   with `DESCRPTION` checks. Each name is a package name,
@@ -24,8 +26,18 @@ issues_descriptions <- function(meta = meta_packages()) {
   meta <- issues_descriptions_advisories(meta)
   meta <- issues_descriptions_licenses(meta)
   meta <- issues_descriptions_remotes(meta)
+  meta <- issues_descriptions_version_conflict(meta, repo = "cran")
+  meta <- issues_descriptions_version_conflict(meta, repo = "bioconductor")
   meta <- meta[meta$issue,, drop = FALSE] # nolint
-  issues_list(meta[, c("package", "advisories", "license", "remotes")])
+  fields <- c(
+    "package",
+    "advisories",
+    "license",
+    "remotes",
+    "cran",
+    "bioconductor"
+  )
+  issues_list(meta[, fields])
 }
 
 issues_descriptions_advisories <- function(meta) {
@@ -51,5 +63,21 @@ issues_descriptions_remotes <- function(meta) {
   meta[["remotes"]] <- meta[["remotes"]] %||% replicate(nrow(meta), NULL)
   meta$remotes <- lapply(meta$remotes, function(x) x[nzchar(x)])
   meta$issue <- meta$issue | vapply(meta$remotes, length, integer(1L)) > 0L
+  meta
+}
+
+issues_descriptions_version_conflict <- function(meta, repo) {
+  conflict <- vapply(
+    X = seq_len(nrow(meta)),
+    FUN = function(index) {
+      utils::compareVersion(
+        a = meta$version[index],
+        b = meta[[repo]][index]
+      ) < 0L
+    },
+    FUN.VALUE = logical(1L)
+  )
+  meta[[repo]][!conflict] <- NA_character_
+  meta$issue <- meta$issue | conflict
   meta
 }

--- a/R/issues_descriptions.R
+++ b/R/issues_descriptions.R
@@ -8,8 +8,8 @@
 #'     <https://github.com/RConsortium/r-advisory-database>.
 #'   2. Licenses that cannot be verified as free and open-source.
 #'   3. The presence of a `"Remotes"` field.
-#'   4. A lower version number on R-multiverse than on CRAN or Bioconductor,
-#'     if the package is on either of these other package repositories.
+#'   4. A lower version number on R-multiverse than on CRAN,
+#'     if the package is also published on the latter.
 #' @inheritSection record_issues Package issues
 #' @return A named list of information about packages which do not comply
 #'   with `DESCRPTION` checks. Each name is a package name,
@@ -27,15 +27,13 @@ issues_descriptions <- function(meta = meta_packages()) {
   meta <- issues_descriptions_licenses(meta)
   meta <- issues_descriptions_remotes(meta)
   meta <- issues_descriptions_version_conflict(meta, repo = "cran")
-  meta <- issues_descriptions_version_conflict(meta, repo = "bioconductor")
   meta <- meta[meta$issue,, drop = FALSE] # nolint
   fields <- c(
     "package",
     "advisories",
     "license",
     "remotes",
-    "cran",
-    "bioconductor"
+    "cran"
   )
   issues_list(meta[, fields])
 }

--- a/R/meta_packages.R
+++ b/R/meta_packages.R
@@ -29,5 +29,19 @@ meta_packages <- function(
   foss <- utils::available.packages(repos = repo, filters = "license/FOSS")
   out$foss <- FALSE
   out[as.character(foss[, "Package"]), "foss"] <- TRUE
+  cran <- utils::available.packages(repos = "https://cloud.r-project.org")
+  cran <- data.frame(
+    package = as.character(cran[, "Package"]),
+    cran = as.character(cran[, "Version"])
+  )
+  repos <- suppressMessages(BiocManager::repositories())
+  repos <- repos[names(repos) != "CRAN"]
+  bioconductor <- utils::available.packages(repos = repos)
+  bioconductor <- data.frame(
+    package = as.character(bioconductor[, "Package"]),
+    bioconductor = as.character(bioconductor[, "Version"])
+  )
+  out <- merge(x = out, y = cran, all.x = TRUE, all.y = FALSE)
+  out <- merge(x = out, y = bioconductor, all.x = TRUE, all.y = FALSE)
   out
 }

--- a/R/meta_packages.R
+++ b/R/meta_packages.R
@@ -40,7 +40,7 @@ meta_packages <- function(
   foss <- utils::available.packages(repos = repo, filters = "license/FOSS")
   out$foss <- FALSE
   out[as.character(foss[, "Package"]), "foss"] <- TRUE
-  freeze <- meta_packages_staging_freeze()
+  freeze <- date_staging_freeze()
   p3m <- "https://packagemanager.posit.co"
   repo_cran <- file.path(p3m, "cran", freeze)
   cran <- utils::available.packages(repos = repo_cran)
@@ -50,13 +50,4 @@ meta_packages <- function(
   )
   out <- merge(x = out, y = cran, all.x = TRUE, all.y = FALSE)
   out
-}
-
-meta_packages_staging_freeze <- function() {
-  today <- Sys.Date()
-  year <- as.integer(format(today, "%Y"))
-  years <- as.character(rep(c(year - 1L, year), each = 4L))
-  months <- rep(c("01-15", "04-15", "07-15", "10-15"), times = 2L)
-  freezes <- as.Date(paste(years, months, sep = "-"))
-  as.character(max(freezes[freezes <= today]))
 }

--- a/R/propose_snapshot.R
+++ b/R/propose_snapshot.R
@@ -39,7 +39,7 @@ propose_snapshot <- function(
   path_staging,
   repo_staging = "https://staging.r-multiverse.org",
   types = c("src", "win", "mac"),
-  r_versions = gsub("\\.[0-9]*$", "", rversions::r_release()$version),
+  r_versions = rversions::r_release()$version,
   mock = NULL
 ) {
   path_issues <- file.path(path_staging, "issues.json")

--- a/R/update_staging.R
+++ b/R/update_staging.R
@@ -76,5 +76,13 @@ update_staging <- function(
   json_new <- rbind(json_freeze, json_update)
   json_new <- json_new[order(json_new$package), ]
   jsonlite::write_json(json_new, file_staging, pretty = TRUE)
+  file_config <- file.path(path_staging, "config.json")
+  json_config <- list(cran_version = date_staging_freeze())
+  jsonlite::write_json(
+    json_config,
+    file_config,
+    pretty = TRUE,
+    auto_unbox = TRUE
+  )
   invisible()
 }

--- a/R/utils_date.R
+++ b/R/utils_date.R
@@ -1,0 +1,8 @@
+date_staging_freeze <- function() {
+  today <- Sys.Date()
+  year <- as.integer(format(today, "%Y"))
+  years <- as.character(rep(c(year - 1L, year), each = 4L))
+  months <- rep(c("01-15", "04-15", "07-15", "10-15"), times = 2L)
+  freezes <- as.Date(paste(years, months, sep = "-"))
+  as.character(max(freezes[freezes <= today]))
+}

--- a/man/issues_descriptions.Rd
+++ b/man/issues_descriptions.Rd
@@ -28,7 +28,7 @@ Report issues with \code{DESCRIPTION}-level metadata of packages.
 \item Licenses that cannot be verified as free and open-source.
 \item The presence of a \code{"Remotes"} field.
 \item A lower version number on R-multiverse than on CRAN,
-if the package is also published on the latter.
+if the package is also published there.
 }
 }
 \section{Package issues}{

--- a/man/issues_descriptions.Rd
+++ b/man/issues_descriptions.Rd
@@ -27,6 +27,8 @@ Report issues with \code{DESCRIPTION}-level metadata of packages.
 \url{https://github.com/RConsortium/r-advisory-database}.
 \item Licenses that cannot be verified as free and open-source.
 \item The presence of a \code{"Remotes"} field.
+\item A lower version number on R-multiverse than on CRAN or Bioconductor,
+if the package is on either of these other package repositories.
 }
 }
 \section{Package issues}{

--- a/man/issues_descriptions.Rd
+++ b/man/issues_descriptions.Rd
@@ -27,8 +27,8 @@ Report issues with \code{DESCRIPTION}-level metadata of packages.
 \url{https://github.com/RConsortium/r-advisory-database}.
 \item Licenses that cannot be verified as free and open-source.
 \item The presence of a \code{"Remotes"} field.
-\item A lower version number on R-multiverse than on CRAN or Bioconductor,
-if the package is on either of these other package repositories.
+\item A lower version number on R-multiverse than on CRAN,
+if the package is also published on the latter.
 }
 }
 \section{Package issues}{

--- a/man/meta_packages.Rd
+++ b/man/meta_packages.Rd
@@ -17,7 +17,20 @@ R-multiverse uses \code{"https://community.r-multiverse.org"}.}
 }
 \value{
 A data frame with one row per package and columns with package
-metadata.
+metadata. The most important columns are:
+\itemize{
+\item \code{package}: character vector of package names.
+\item \code{version}: character vector of package versions in the repo.
+\item \code{license}: character vector of license names.
+\item \code{remotesha}: character vector of GitHub/GitLab commit hashes.
+\item \code{remotes}: list of character vectors with dependencies in the
+\verb{Remotes:} field of the \code{DESCRIPTION} files.
+\item \code{foss}: \code{TRUE} if the package has a valid free open-source license,
+\code{FALSE} otherwise.
+\item \code{cran}: character vector of versions. Each version is the version of
+the package that was on CRAN during the first day of the most recent
+R-multiverse staging period.
+}
 }
 \description{
 List package metadata in an R universe.

--- a/man/propose_snapshot.Rd
+++ b/man/propose_snapshot.Rd
@@ -8,7 +8,7 @@ propose_snapshot(
   path_staging,
   repo_staging = "https://staging.r-multiverse.org",
   types = c("src", "win", "mac"),
-  r_versions = gsub("\\\\.[0-9]*$", "", rversions::r_release()$version),
+  r_versions = rversions::r_release()$version,
   mock = NULL
 )
 }

--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -644,11 +644,6 @@ mock_meta_packages <- structure(
       "1.0.0", NA, NA, NA, "0.0.1", "0.0.1", "0.0.1", "1.1.0",
       NA, NA, "0.0.1", NA, "0.0.1", NA, "0.0.1", NA, NA, NA, "0.0.1",
       NA
-    ),
-    bioconductor = c(
-      rep(NA_character_, 13L),
-      "9.0.0",
-      rep(NA_character_, 6L)
     )
   ),
   class = "data.frame",
@@ -781,8 +776,7 @@ mock_meta_packages_graph <- structure(
     ),
     distro = c("noble", "noble", "noble", "noble", "noble"),
     foss = rep(TRUE, 5L),
-    cran = rep(NA_character_, 5L),
-    bioconductor = rep(NA_character_, 5L)
+    cran = rep(NA_character_, 5L)
   ),
   class = "data.frame",
   row.names = c(NA, 5L)

--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -639,7 +639,13 @@ mock_meta_packages <- structure(
       c("hyunjimoon/SBC", "stan-dev/cmdstanr", ""), NULL, NULL,
       "markvanderloo/tinytest/pkg", NULL, NULL, NULL
     ),
-    foss = c(rep(TRUE, 15L), FALSE, rep(TRUE, 4L))
+    foss = c(rep(TRUE, 15L), FALSE, rep(TRUE, 4L)),
+    cran = c(
+      "1.0.0", NA, NA, NA, "1.1.3-2", "2.0.2", "1.5.5", "2.1.0", 
+      NA, NA, "1.5.0", NA, "1.0.4", NA, "0.2.0", NA, NA, NA, "1.4.1", 
+      NA
+    ),
+    bioconductor = rep(NA_character_, 20L)
   ),
   class = "data.frame",
   row.names = c(NA, 20L)

--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -641,11 +641,15 @@ mock_meta_packages <- structure(
     ),
     foss = c(rep(TRUE, 15L), FALSE, rep(TRUE, 4L)),
     cran = c(
-      "1.0.0", NA, NA, NA, "1.1.3-2", "2.0.2", "1.5.5", "2.1.0", 
-      NA, NA, "1.5.0", NA, "1.0.4", NA, "0.2.0", NA, NA, NA, "1.4.1", 
+      "1.0.0", NA, NA, NA, "0.0.1", "0.0.1", "0.0.1", "1.1.0",
+      NA, NA, "0.0.1", NA, "0.0.1", NA, "0.0.1", NA, NA, NA, "0.0.1",
       NA
     ),
-    bioconductor = rep(NA_character_, 20L)
+    bioconductor = c(
+      rep(NA_character_, 13L),
+      "9.0.0",
+      rep(NA_character_, 6L)
+    )
   ),
   class = "data.frame",
   row.names = c(NA, 20L)
@@ -776,7 +780,9 @@ mock_meta_packages_graph <- structure(
       )
     ),
     distro = c("noble", "noble", "noble", "noble", "noble"),
-    foss = rep(TRUE, 5L)
+    foss = rep(TRUE, 5L),
+    cran = rep(NA_character_, 5L),
+    bioconductor = rep(NA_character_, 5L)
   ),
   class = "data.frame",
   row.names = c(NA, 5L)

--- a/tests/testthat/test-interpret_status.R
+++ b/tests/testthat/test-interpret_status.R
@@ -119,6 +119,18 @@ test_that("interpret_status() checks etc.", {
       fixed = TRUE
     )
   )
+  expect_true(
+    grepl(
+      "On CRAN",
+      interpret_status("SBC", issues)
+    )
+  )
+  expect_true(
+    grepl(
+      "On Bioconductor",
+      interpret_status("stantargets", issues)
+    )
+  )
   issues$tidypolars$dependencies <- list(x = "y")
   expect_true(
     grepl(

--- a/tests/testthat/test-interpret_status.R
+++ b/tests/testthat/test-interpret_status.R
@@ -125,12 +125,6 @@ test_that("interpret_status() checks etc.", {
       interpret_status("SBC", issues)
     )
   )
-  expect_true(
-    grepl(
-      "On Bioconductor",
-      interpret_status("stantargets", issues)
-    )
-  )
   issues$tidypolars$dependencies <- list(x = "y")
   expect_true(
     grepl(

--- a/tests/testthat/test-issues_descriptions.R
+++ b/tests/testthat/test-issues_descriptions.R
@@ -3,8 +3,7 @@ test_that("issues_descriptions() mocked", {
   expected <- list(
     audio.whisper = list(remotes = "bnosac/audio.vadwebrtc"),
     stantargets = list(
-      remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr"),
-      bioconductor = "9.0.0"
+      remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr")
     ),
     SBC = list(cran = "1.0.0"),
     targetsketch = list(license = "non-standard"),
@@ -51,8 +50,7 @@ test_that("issues_descriptions() with security advisories", {
       )
     ),
     stantargets = list(
-      remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr"),
-      bioconductor = "9.0.0"
+      remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr")
     ),
     SBC = list(cran = "1.0.0"),
     targetsketch = list(license = "non-standard"),

--- a/tests/testthat/test-issues_descriptions.R
+++ b/tests/testthat/test-issues_descriptions.R
@@ -3,12 +3,16 @@ test_that("issues_descriptions() mocked", {
   expected <- list(
     audio.whisper = list(remotes = "bnosac/audio.vadwebrtc"),
     stantargets = list(
-      remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr")
+      remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr"),
+      bioconductor = "9.0.0"
     ),
+    SBC = list(cran = "1.0.0"),
     targetsketch = list(license = "non-standard"),
     tidypolars = list(remotes = "markvanderloo/tinytest/pkg")
   )
-  expect_equal(issues, expected)
+  names <- sort(names(issues))
+  expect_equal(names, sort(names(expected)))
+  expect_equal(issues[names], expected[names])
 })
 
 test_that("issues_descriptions() on a small repo", {
@@ -46,9 +50,15 @@ test_that("issues_descriptions() with security advisories", {
         "blob/main/vulns/readxl/RSEC-2023-2.yaml"
       )
     ),
-    stantargets = list(remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr")),
+    stantargets = list(
+      remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr"),
+      bioconductor = "9.0.0"
+    ),
+    SBC = list(cran = "1.0.0"),
     targetsketch = list(license = "non-standard"),
     tidypolars = list(remotes = "markvanderloo/tinytest/pkg")
   )
-  expect_equal(out, exp)
+  names <- sort(names(out))
+  expect_equal(names, sort(names(exp)))
+  expect_equal(out[names], exp[names])
 })

--- a/tests/testthat/test-meta_checks.R
+++ b/tests/testthat/test-meta_checks.R
@@ -5,3 +5,150 @@ test_that("meta_checks()", {
   fields <- c("package", "url", "issues")
   expect_true(all(fields %in% colnames(out)))
 })
+
+test_that("meta_checks_process_json() with a source failure", {
+  json <- structure(
+    list(
+      Package = c("mirai", "crew"),
+      "_user" = c("r-multiverse-staging", "r-multiverse-staging"),
+      "_type" = c("src", "src"),
+      "_commit" = structure(
+        list(
+          id = c(
+            "645738f41fbfac835bbce76596d6f924ce3c9549",
+            "859a9b465e25e0ced329c36206488fb61382880c"
+          )
+        ),
+        row.names = c(6L, 13L),
+        class = "data.frame"
+      ),
+      "_status" = c("success", "success"),
+      "_buildurl" = c(
+        "https://github.com/r-universe/r-multiverse-staging/buildurl",
+        "https://github.com/r-universe/r-multiverse-staging/buildurl"
+      ),
+      "_indexed" = c(FALSE, FALSE),
+      "_binaries" = list(
+        structure(
+          list(
+            r = c(
+              "4.5.0", "4.4.2", "4.5.0", "4.3.3", "4.4.2", "4.3.3", 
+              "4.4.1", "4.5.0", "4.3.3", "4.4.2"
+            ),
+            os = c("linux", "linux", 
+                   "mac", "mac", "mac", "wasm", "wasm", "win", "win", "win"
+            ), 
+            commit = c(
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549",
+              "645738f41fbfac835bbce76596d6f924ce3c9549"
+            ),
+            status = c(
+              "success", "success", "success", "success", 
+              "success", "success", "success", "success", "success", "success"
+            ),
+            check = c(
+              "OK", NA, "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"),
+            buildurl = c(
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary"
+            )
+          ),
+          class = "data.frame",
+          row.names = c(NA, 10L)
+        ),
+        structure(
+          list(
+            r = c(
+              "4.5.0", "4.4.2", "4.3.3", "4.4.2", "4.3.3", "4.4.1", 
+              "4.5.0", "4.3.3", "4.4.2"
+            ),
+            os = c(
+              "linux", "linux", "mac", 
+              "mac", "wasm", "wasm", "win", "win", "win"
+            ),
+            commit = c(
+              "859a9b465e25e0ced329c36206488fb61382880c",
+              "859a9b465e25e0ced329c36206488fb61382880c",
+              "859a9b465e25e0ced329c36206488fb61382880c",
+              "859a9b465e25e0ced329c36206488fb61382880c",
+              "859a9b465e25e0ced329c36206488fb61382880c",
+              "859a9b465e25e0ced329c36206488fb61382880c",
+              "859a9b465e25e0ced329c36206488fb61382880c", 
+              "859a9b465e25e0ced329c36206488fb61382880c",
+              "859a9b465e25e0ced329c36206488fb61382880c"
+            ),
+            status = c(
+              "success", "success", "success", "success", 
+              "success", "success", "success", "success", "success"
+            ),
+            check = c("OK", NA, "OK", "OK", NA, NA, "OK", "OK", "OK"),
+            buildurl = c(
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary"
+            )
+          ),
+          class = "data.frame",
+          row.names = c(NA, 9L)
+        )
+      ),
+      "_failure" = structure(
+        list(
+          commit = structure(
+            list(
+              id = c(NA, "859a9b465e25e0ced329c36206488fb61382880c"
+              )
+            ),
+            row.names = c(6L, 13L),
+            class = "data.frame"
+          ),
+          buildurl = c(
+            NA, 
+            "https://github.com/r-universe/r-multiverse-staging/falure"
+          )
+        ),
+        row.names = c(6L, 13L),
+        class = "data.frame")
+    ),
+    row.names = c(6L, 13L),
+    class = "data.frame"
+  )
+  out <- meta_checks_process_json(json)
+  expect_equal(nrow(out), 2L)
+  expect_equal(sort(out$package), sort(c("crew", "mirai")))
+  expect_equal(
+    out$url[out$package == "mirai"],
+    "https://github.com/r-universe/r-multiverse-staging/buildurl"
+  )
+  expect_equal(
+    out$url[out$package == "crew"],
+    "https://github.com/r-universe/r-multiverse-staging/falure"
+  )
+  expect_equal(out$issues[[which(out$package == "mirai")]], list())
+  expect_equal(
+    out$issues[[which(out$package == "crew")]],
+    list(source = "FAILURE")
+  )
+})

--- a/tests/testthat/test-meta_checks.R
+++ b/tests/testthat/test-meta_checks.R
@@ -147,7 +147,7 @@ test_that("meta_checks_process_json() with a source failure", {
   )
   expect_equal(
     out$url[out$package == "crew"],
-    "https://github.com/r-universe/r-multiverse-staging/falure"
+    "https://github.com/r-universe/r-multiverse-staging/failure"
   )
   expect_equal(out$issues[[which(out$package == "mirai")]], list())
   expect_equal(

--- a/tests/testthat/test-meta_checks.R
+++ b/tests/testthat/test-meta_checks.R
@@ -128,7 +128,7 @@ test_that("meta_checks_process_json() with a source failure", {
           ),
           buildurl = c(
             NA,
-            "https://github.com/r-universe/r-multiverse-staging/falure"
+            "https://github.com/r-universe/r-multiverse-staging/failure"
           )
         ),
         row.names = c(6L, 13L),

--- a/tests/testthat/test-meta_checks.R
+++ b/tests/testthat/test-meta_checks.R
@@ -32,12 +32,13 @@ test_that("meta_checks_process_json() with a source failure", {
         structure(
           list(
             r = c(
-              "4.5.0", "4.4.2", "4.5.0", "4.3.3", "4.4.2", "4.3.3", 
+              "4.5.0", "4.4.2", "4.5.0", "4.3.3", "4.4.2", "4.3.3",
               "4.4.1", "4.5.0", "4.3.3", "4.4.2"
             ),
-            os = c("linux", "linux", 
-                   "mac", "mac", "mac", "wasm", "wasm", "win", "win", "win"
-            ), 
+            os = c(
+              "linux", "linux",
+              "mac", "mac", "mac", "wasm", "wasm", "win", "win", "win"
+            ),
             commit = c(
               "645738f41fbfac835bbce76596d6f924ce3c9549",
               "645738f41fbfac835bbce76596d6f924ce3c9549",
@@ -51,21 +52,22 @@ test_that("meta_checks_process_json() with a source failure", {
               "645738f41fbfac835bbce76596d6f924ce3c9549"
             ),
             status = c(
-              "success", "success", "success", "success", 
+              "success", "success", "success", "success",
               "success", "success", "success", "success", "success", "success"
             ),
             check = c(
-              "OK", NA, "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"),
+              "OK", NA, "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"
+            ),
             buildurl = c(
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
               "https://github.com/r-universe/r-multiverse-staging/binary"
             )
           ),
@@ -75,11 +77,11 @@ test_that("meta_checks_process_json() with a source failure", {
         structure(
           list(
             r = c(
-              "4.5.0", "4.4.2", "4.3.3", "4.4.2", "4.3.3", "4.4.1", 
+              "4.5.0", "4.4.2", "4.3.3", "4.4.2", "4.3.3", "4.4.1",
               "4.5.0", "4.3.3", "4.4.2"
             ),
             os = c(
-              "linux", "linux", "mac", 
+              "linux", "linux", "mac",
               "mac", "wasm", "wasm", "win", "win", "win"
             ),
             commit = c(
@@ -89,24 +91,24 @@ test_that("meta_checks_process_json() with a source failure", {
               "859a9b465e25e0ced329c36206488fb61382880c",
               "859a9b465e25e0ced329c36206488fb61382880c",
               "859a9b465e25e0ced329c36206488fb61382880c",
-              "859a9b465e25e0ced329c36206488fb61382880c", 
+              "859a9b465e25e0ced329c36206488fb61382880c",
               "859a9b465e25e0ced329c36206488fb61382880c",
               "859a9b465e25e0ced329c36206488fb61382880c"
             ),
             status = c(
-              "success", "success", "success", "success", 
+              "success", "success", "success", "success",
               "success", "success", "success", "success", "success"
             ),
             check = c("OK", NA, "OK", "OK", NA, NA, "OK", "OK", "OK"),
             buildurl = c(
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
-              "https://github.com/r-universe/r-multiverse-staging/binary", 
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
+              "https://github.com/r-universe/r-multiverse-staging/binary",
               "https://github.com/r-universe/r-multiverse-staging/binary"
             )
           ),
@@ -125,12 +127,13 @@ test_that("meta_checks_process_json() with a source failure", {
             class = "data.frame"
           ),
           buildurl = c(
-            NA, 
+            NA,
             "https://github.com/r-universe/r-multiverse-staging/falure"
           )
         ),
         row.names = c(6L, 13L),
-        class = "data.frame")
+        class = "data.frame"
+      )
     ),
     row.names = c(6L, 13L),
     class = "data.frame"

--- a/tests/testthat/test-meta_packages.R
+++ b/tests/testthat/test-meta_packages.R
@@ -5,7 +5,9 @@ test_that("meta_packages()", {
   fields <- c(
     "package",
     "version",
-    "remotesha"
+    "remotesha",
+    "cran",
+    "bioconductor"
   )
   expect_true(all(fields %in% colnames(out)))
 })

--- a/tests/testthat/test-meta_packages.R
+++ b/tests/testthat/test-meta_packages.R
@@ -6,8 +6,7 @@ test_that("meta_packages()", {
     "package",
     "version",
     "remotesha",
-    "cran",
-    "bioconductor"
+    "cran"
   )
   expect_true(all(fields %in% colnames(out)))
 })

--- a/tests/testthat/test-propose_snapshot.R
+++ b/tests/testthat/test-propose_snapshot.R
@@ -49,7 +49,7 @@ test_that("propose_snapshot()", {
       "https://staging.r-multiverse.org/api/snapshot/zip",
       "?types=src,win,mac",
       "&binaries=",
-      gsub("\\.[0-9]*$", "", rversions::r_release()$version),
+      rversions::r_release()$version,
       "&packages=good1,good2"
     )
   )

--- a/tests/testthat/test-propose_snapshot.R
+++ b/tests/testthat/test-propose_snapshot.R
@@ -28,9 +28,11 @@ test_that("propose_snapshot()", {
     package = c("good1", "good2", "issue", "removed", "unsynced"),
     remotesha = c(rep("original", 4), "sha-unsynced")
   )
+  version <- rversions::r_release()$version
   propose_snapshot(
     path_staging = path_staging,
-    mock = list(staging = meta_staging)
+    mock = list(staging = meta_staging),
+    r_versions = version
   )
   json_snapshot <- jsonlite::read_json(
     file.path(path_staging, "snapshot.json"),
@@ -49,7 +51,7 @@ test_that("propose_snapshot()", {
       "https://staging.r-multiverse.org/api/snapshot/zip",
       "?types=src,win,mac",
       "&binaries=",
-      rversions::r_release()$version,
+      version,
       "&packages=good1,good2"
     )
   )

--- a/tests/testthat/test-record_issues.R
+++ b/tests/testthat/test-record_issues.R
@@ -52,8 +52,7 @@ test_that("record_issues() mocked", {
         )
       ),
       descriptions = list(
-        remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr"),
-        bioconductor = "9.0.0"
+        remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr")
       ),
       date = "2024-01-01",
       version = "0.1.1",

--- a/tests/testthat/test-record_issues.R
+++ b/tests/testthat/test-record_issues.R
@@ -52,7 +52,8 @@ test_that("record_issues() mocked", {
         )
       ),
       descriptions = list(
-        remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr")
+        remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr"),
+        bioconductor = "9.0.0"
       ),
       date = "2024-01-01",
       version = "0.1.1",

--- a/tests/testthat/test-update_staging.R
+++ b/tests/testthat/test-update_staging.R
@@ -22,6 +22,7 @@ test_that("update_staging()", {
     to = dir_community,
     recursive = TRUE
   )
+  file_config <- file.path(path_staging, "config.json")
   file_staging <- file.path(path_staging, "packages.json")
   file_community <- file.path(path_community, "packages.json")
   json_staging <- jsonlite::read_json(file_staging)
@@ -40,6 +41,9 @@ test_that("update_staging()", {
     path_community = path_community,
     mock = list(community = meta_community)
   )
+  config <- jsonlite::read_json(file_config, simplifyVector = TRUE)
+  expect_equal(names(config), "cran_version")
+  expect_true(is.character(config$cran_version))
   packages <- jsonlite::read_json(file_staging, simplifyVector = TRUE)
   expect_true(is.data.frame(packages))
   expect_equal(dim(packages), c(4L, 3L))


### PR DESCRIPTION
* Detect source failures as issues.
* Flag R-multiverse packages whose CRAN versions from the day of the Staging freeze are higher than the current versions in R-multiverse.
* Use the whole R version in `propose_snapshot()` so downstream automation can grep the snapshot URL for the version instead of needing to install R and the `rversions` package.

c.f. https://github.com/r-multiverse/help/discussions/129