### PR TITLE
Target Linux R-release instead of Linux R-devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal infrastructure package to
   automate contribution reviews and populate universes.
-Version: 0.3.8
+Version: 0.3.9
 License: MIT + file LICENSE
 URL:
   https://r-multiverse.org/multiverse.internals/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# multiverse.internals 0.3.9
+
+* Target Linux R-release instead of Linux R-devel (#112).
+
 # multiverse.internals 0.3.8
 
 * In the status repo, list all packages with check issues for each of Community and Staging.

--- a/R/meta_checks.R
+++ b/R/meta_checks.R
@@ -39,19 +39,17 @@ meta_checks_issues_binaries <- function(binaries) {
   os <- .subset2(binaries, "os")
   arch <- .subset2(binaries, "arch")
   r <- .subset2(binaries, "r")
-  devel <- is_r_devel(r)
-  release <- is_r_release(r)
+  is_release <- r_version_short(r) == staging_r_version()$short
   results <- c(
-    target_check("linux", "R-devel", os, arch, r, devel, check),
-    target_check("mac", "R-release", os, arch, r, release, check),
-    target_check("win", "R-release", os, arch, r, release, check)
+    target_check("linux", os, arch, r, is_release, check),
+    target_check("mac", os, arch, r, is_release, check),
+    target_check("win", os, arch, r, is_release, check)
   )
   as.list(results)
 }
 
 target_check <- function(
   target_os,
-  target_r,
   os,
   arch,
   r,
@@ -61,7 +59,7 @@ target_check <- function(
   is_target <- (target_os == os) & is_target_r
   if (!any(is_target) || all(is.na(check[is_target]))) {
     out <- "MISSING"
-    names(out) <- paste0(target_os, " ", target_r)
+    names(out) <- target_os
     return(out)
   }
   is_failure <- is_target & check %in% c("WARNING", "ERROR")
@@ -77,15 +75,4 @@ target_check <- function(
   }
   names(check) <- paste(os, r, sep = " ")
   check
-}
-
-is_r_release <- function(r) {
-  r_version_short(r) == staging_r_version()$short
-}
-
-is_r_devel <- function(r) {
-  major <- r_version_major(r)
-  minor <- r_version_minor(r)
-  staging <- staging_r_version()
-  major > staging$major | ((major == staging$major) & (minor > staging$minor))
 }

--- a/tests/testthat/test-meta_checks.R
+++ b/tests/testthat/test-meta_checks.R
@@ -56,7 +56,7 @@ test_that("meta_checks_process_json() with a source failure", {
               "success", "success", "success", "success", "success", "success"
             ),
             check = c(
-              "OK", NA, "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"
+              "OK", "OK", "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"
             ),
             buildurl = c(
               "https://github.com/r-universe/r-multiverse-staging/binary",
@@ -99,7 +99,7 @@ test_that("meta_checks_process_json() with a source failure", {
               "success", "success", "success", "success",
               "success", "success", "success", "success", "success"
             ),
-            check = c("OK", NA, "OK", "OK", NA, NA, "OK", "OK", "OK"),
+            check = c("OK", "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"),
             buildurl = c(
               "https://github.com/r-universe/r-multiverse-staging/binary",
               "https://github.com/r-universe/r-multiverse-staging/binary",


### PR DESCRIPTION
Discussed in https://github.com/r-multiverse/help/issues/112. Production depends on a specific version of base R that we now target in advance. I don't think it makes sense to enforce R-devel checks, just R-release on the main platforms.

Thankfully, I was able to test this in spite of the r-multiverse.org being down. It turns out community.r-multiverse.org and production.r-multiverse.org are still live.