### PR TITLE
Finalize Staging and organize snapshot metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal infrastructure package to
   automate contribution reviews and populate universes.
-Version: 0.3.8
+Version: 0.3.9
 License: MIT + file LICENSE
 URL:
   https://r-multiverse.org/multiverse.internals/,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal infrastructure package to
   automate contribution reviews and populate universes.
-Version: 0.3.9
+Version: 0.3.10
 License: MIT + file LICENSE
 URL:
   https://r-multiverse.org/multiverse.internals/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# multiverse.internals 0.3.10
+
+* Download all of staging in `propose_snapshot()` assuming staging has been finalized (contains only healthy packages) (#144).
+* Organize R version and snapshot/staging date information more neatly in `meta.json`.
+
 # multiverse.internals 0.3.9
 
 * Target Linux R-release instead of Linux R-devel (#112).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# multiverse.internals 0.3.9
+
+* Target Linux R-release instead of Linux R-devel (#112).
+
 # multiverse.internals 0.3.8
 
 * In the status repo, list all packages with check issues for each of Community and Staging.

--- a/R/meta_checks.R
+++ b/R/meta_checks.R
@@ -39,19 +39,17 @@ meta_checks_issues_binaries <- function(binaries) {
   os <- .subset2(binaries, "os")
   arch <- .subset2(binaries, "arch")
   r <- .subset2(binaries, "r")
-  devel <- is_r_devel(r)
-  release <- is_r_release(r)
+  is_release <- r_version_short(r) == staging_r_version()$short
   results <- c(
-    target_check("linux", "R-devel", os, arch, r, devel, check),
-    target_check("mac", "R-release", os, arch, r, release, check),
-    target_check("win", "R-release", os, arch, r, release, check)
+    target_check("linux", os, arch, r, is_release, check),
+    target_check("mac", os, arch, r, is_release, check),
+    target_check("win", os, arch, r, is_release, check)
   )
   as.list(results)
 }
 
 target_check <- function(
   target_os,
-  target_r,
   os,
   arch,
   r,
@@ -61,7 +59,7 @@ target_check <- function(
   is_target <- (target_os == os) & is_target_r
   if (!any(is_target) || all(is.na(check[is_target]))) {
     out <- "MISSING"
-    names(out) <- paste0(target_os, " ", target_r)
+    names(out) <- target_os
     return(out)
   }
   is_failure <- is_target & check %in% c("WARNING", "ERROR")
@@ -77,15 +75,4 @@ target_check <- function(
   }
   names(check) <- paste(os, r, sep = " ")
   check
-}
-
-is_r_release <- function(r) {
-  r_version_short(r) == staging_r_version()$short
-}
-
-is_r_devel <- function(r) {
-  major <- r_version_major(r)
-  minor <- r_version_minor(r)
-  staging <- staging_r_version()
-  major > staging$major | ((major == staging$major) & (minor > staging$minor))
 }

--- a/R/propose_snapshot.R
+++ b/R/propose_snapshot.R
@@ -65,20 +65,20 @@ propose_snapshot <- function(
     "https://staging.r-multiverse.org/api/snapshot/zip",
     "?types=",
     paste(types, collapse = ","),
-    binaries,
-    "&packages=",
-    paste(staging$package, collapse = ",")
+    binaries
   )
   writeLines(url, file.path(path_staging, "snapshot.url"))
-  writeLines(r_version$full, file.path(path_staging, "r_version_full.txt"))
-  writeLines(r_version$short, file.path(path_staging, "r_version_short.txt"))
-  writeLines(
-    staging_start(),
-    file.path(path_staging, "date_staging_start.txt")
+  meta <- list(
+    date = data.frame(
+      staging = staging_start(),
+      snapshot = as.character(Sys.Date())
+    ),
+    r_version = r_version[c("full", "short")]
   )
-  writeLines(
-    as.character(Sys.Date()),
-    file.path(path_staging, "date_snapshot.txt")
+  jsonlite::write_json(
+    meta,
+    file.path(path_staging, "meta.json"),
+    pretty = TRUE
   )
   invisible()
 }

--- a/tests/testthat/test-meta_checks.R
+++ b/tests/testthat/test-meta_checks.R
@@ -56,7 +56,7 @@ test_that("meta_checks_process_json() with a source failure", {
               "success", "success", "success", "success", "success", "success"
             ),
             check = c(
-              "OK", NA, "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"
+              "OK", "OK", "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"
             ),
             buildurl = c(
               "https://github.com/r-universe/r-multiverse-staging/binary",
@@ -99,7 +99,7 @@ test_that("meta_checks_process_json() with a source failure", {
               "success", "success", "success", "success",
               "success", "success", "success", "success", "success"
             ),
-            check = c("OK", NA, "OK", "OK", NA, NA, "OK", "OK", "OK"),
+            check = c("OK", "OK", "OK", "OK", NA, NA, "OK", "OK", "OK"),
             buildurl = c(
               "https://github.com/r-universe/r-multiverse-staging/binary",
               "https://github.com/r-universe/r-multiverse-staging/binary",

--- a/tests/testthat/test-propose_snapshot.R
+++ b/tests/testthat/test-propose_snapshot.R
@@ -49,24 +49,16 @@ test_that("propose_snapshot()", {
       "https://staging.r-multiverse.org/api/snapshot/zip",
       "?types=src,win,mac",
       "&binaries=",
-      staging_r_version()$short,
-      "&packages=good1,good2"
+      staging_r_version()$short
     )
   )
-  expect_equal(
-    readLines(file.path(path_staging, "date_snapshot.txt")),
-    as.character(Sys.Date())
+  meta <- jsonlite::read_json(
+    file.path(path_staging, "meta.json"),
+    simplifyVector = TRUE
   )
-  expect_equal(
-    readLines(file.path(path_staging, "date_staging_start.txt")),
-    as.character(staging_start())
-  )
-  expect_equal(
-    readLines(file.path(path_staging, "r_version_full.txt")),
-    as.character(staging_r_version()$full)
-  )
-  expect_equal(
-    readLines(file.path(path_staging, "r_version_short.txt")),
-    as.character(staging_r_version()$short)
-  )
+  expect_equal(sort(names(meta)), sort(c("date", "r_version")))
+  expect_true(is.character(meta$date$staging))
+  expect_true(is.character(meta$date$snapshot))
+  expect_true(is.character(meta$r_version$full))
+  expect_true(is.character(meta$r_version$short))
 })


### PR DESCRIPTION
* Download all of staging in `propose_snapshot()` assuming staging has been finalized (contains only healthy packages) (#144).
* Organize R version and snapshot/staging date information more neatly in `meta.json`.
