### PR TITLE
Use pre-computed status

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal infrastructure package to
   automate contribution reviews and populate universes.
-Version: 0.4.9
+Version: 0.4.10
 License: MIT + file LICENSE
 URL:
   https://r-multiverse.org/multiverse.internals/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # multiverse.internals 0.4.10
 
-* Simplify `stage_candidates()`: get remote hashes from pre-recorded `issues.json`, as opposed to a separate call to `meta_packages()`. This ensures those remote hashes are more contemporaneous with the corresponding reported check results.
+* Simplify `stage_candidates()` and `rclone_includes()`: get remote hashes from pre-recorded `issues.json`, as opposed to a separate call to `meta_packages()`. This ensures those remote hashes are more contemporaneous with the corresponding reported check results.
 
 # multiverse.internals 0.4.9
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# multiverse.internals 0.4.10
+
+* Simplify `stage_candidates()`: get remote hashes from pre-recorded `issues.json`, as opposed to a separate call to `meta_packages()`. This ensures those remote hashes are more contemporaneous with the corresponding reported check results.
+
 # multiverse.internals 0.4.9
 
 * In `stage_candidates()`, set `"branch": "*release"` in Staging to allow broken packages to update faster.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # multiverse.internals 0.4.10
 
-* Simplify `stage_candidates()` and `rclone_includes()`: get remote hashes from pre-recorded `issues.json`, as opposed to a separate call to `meta_packages()`. This ensures those remote hashes are more contemporaneous with the corresponding reported check results.
+* Simplify `stage_candidates()`, `rclone_includes()`, and `update_status()`: get remote hashes from pre-recorded `issues.json`, as opposed to a separate call to `meta_packages()`. This ensures those remote hashes are more contemporaneous with the corresponding reported check results.
 
 # multiverse.internals 0.4.9
 

--- a/R/rclone_includes.R
+++ b/R/rclone_includes.R
@@ -11,30 +11,21 @@
 #' path_staging <- tempfile()
 #' path_community <- tempfile()
 #' gert::git_clone(url = url_staging, path = path_staging)
-#' stage_candidates(
-#'   path_staging = path_staging,
-#'   repo_staging = "https://staging.r-multiverse.org"
-#' )
-#' rclone_includes(
-#'   path_staging,
-#'   repo_staging = "https://staging.r-multiverse.org"
-#' )
+#' stage_candidates(path_staging = path_staging)
+#' rclone_includes(path_staging)
 #' }
-rclone_includes <- function(
-  path_staging,
-  repo_staging = "https://staging.r-multiverse.org",
-  mock = NULL
-) {
-  write_include_packages(path_staging, repo_staging, mock)
+rclone_includes <- function(path_staging) {
+  write_include_packages(path_staging)
   write_include_meta(path_staging)
 }
 
-write_include_packages <- function(path_staging, repo_staging, mock) {
-  meta_staging <- mock$staging %||% meta_packages(repo_staging)
+write_include_packages <- function(path_staging) {
+  file_issues <- file.path(path_staging, "issues.json")
+  json_issues <- jsonlite::read_json(file_issues, simplifyVector = TRUE)
   staged <- staged_packages(path_staging)
-  is_staged <- meta_staging$package %in% staged
-  package <- meta_staging$package[is_staged]
-  version <- meta_staging$version[is_staged]
+  json_staged <- json_issues[staged]
+  package <- names(json_staged)
+  version <- vapply(json_staged, \(x) x$version, character(1L))
   release <- paste0(package, "_", version)
   r <- meta_snapshot()$r
   source <- sprintf("src/contrib/%s.tar.gz", release)

--- a/R/rclone_includes.R
+++ b/R/rclone_includes.R
@@ -4,7 +4,6 @@
 #' @description Write text files to pass to the `--include-from` flag
 #'   in Rclone when uploading snapshots.
 #' @inheritParams stage_candidates
-#' @param repo_staging Character string, URL of the Staging universe.
 #' @examples
 #' \dontrun{
 #' url_staging = "https://github.com/r-multiverse/staging"

--- a/R/update_topics.R
+++ b/R/update_topics.R
@@ -4,10 +4,10 @@
 #' @description Update the list of packages for each
 #'   R-multiverse topic.
 #' @return `NULL` (invisibly). Called for its side effects.
-#' @inheritParams stage_candidates
 #' @param path Character string,
 #'   local file path to the topics repository source code.
 #' @param repo Character string, URL of the Community universe.
+#' @param mock List of named objects for testing purposes only.
 update_topics <- function(
   path,
   repo = "https://community.r-multiverse.org",

--- a/inst/mock/community/issues.json
+++ b/inst/mock/community/issues.json
@@ -10,19 +10,19 @@
     },
     "success": [false],
     "date": ["1980-01-01"],
-    "version": ["2.0.2"],
-    "remote_hash": ["abcdef1234567890abcdef"]
+    "version": ["2.0.1"],
+    "remote_hash": ["sha-issue"]
   },
   "add": {
     "success": [true],
     "date": ["1980-01-01"],
     "version": ["2.0.2"],
-    "remote_hash": ["abcdef1234567890abcdef"]
+    "remote_hash": ["sha-add"]
   },
   "staged": {
     "success": [true],
     "date": ["1980-01-01"],
-    "version": ["2.0.2"],
-    "remote_hash": ["abcdef1234567890abcdef"]
+    "version": ["2.0.3"],
+    "remote_hash": ["sha-staged"]
   }
 }

--- a/inst/mock/staging/issues.json
+++ b/inst/mock/staging/issues.json
@@ -11,7 +11,7 @@
     "success": [false],
     "date": ["1980-01-01"],
     "version": ["2.0.2"],
-    "remote_hash": ["abcdef1234567890abcdef"]
+    "remote_hash": ["sha-issue"]
   },
   "removed-has-issue": {
     "checks": {
@@ -25,18 +25,18 @@
     "success": [false],
     "date": ["1980-01-01"],
     "version": ["2.0.2"],
-    "remote_hash": ["abcdef1234567890abcdef"]
+    "remote_hash": ["sha-removed-has-issue"]
   },
   "staged": {
     "success": [true],
     "date": ["1980-01-01"],
     "version": ["2.0.2"],
-    "remote_hash": ["abcdef1234567890abcdef"]
+    "remote_hash": ["sha-staged"]
   },
   "removed-no-issue": {
     "success": [true],
     "date": ["1980-01-01"],
     "version": ["2.0.2"],
-    "remote_hash": ["abcdef1234567890abcdef"]
+    "remote_hash": ["sha-removed-no-issue"]
   }
 }

--- a/inst/mock/staging/issues.json
+++ b/inst/mock/staging/issues.json
@@ -10,7 +10,7 @@
     },
     "success": [false],
     "date": ["1980-01-01"],
-    "version": ["2.0.2"],
+    "version": ["2.0.3"],
     "remote_hash": ["sha-issue"]
   },
   "removed-has-issue": {
@@ -24,19 +24,19 @@
     },
     "success": [false],
     "date": ["1980-01-01"],
-    "version": ["2.0.2"],
+    "version": ["2.0.4"],
     "remote_hash": ["sha-removed-has-issue"]
   },
   "staged": {
     "success": [true],
     "date": ["1980-01-01"],
-    "version": ["2.0.2"],
+    "version": ["2.0.5"],
     "remote_hash": ["sha-staged"]
   },
   "removed-no-issue": {
     "success": [true],
     "date": ["1980-01-01"],
-    "version": ["2.0.2"],
+    "version": ["2.0.6"],
     "remote_hash": ["sha-removed-no-issue"]
   }
 }

--- a/man/rclone_includes.Rd
+++ b/man/rclone_includes.Rd
@@ -9,8 +9,6 @@ rclone_includes(path_staging)
 \arguments{
 \item{path_staging}{Character string, directory path to the source
 files of the Staging universe.}
-
-\item{repo_staging}{Character string, URL of the Staging universe.}
 }
 \description{
 Write text files to pass to the \code{--include-from} flag

--- a/man/rclone_includes.Rd
+++ b/man/rclone_includes.Rd
@@ -15,9 +15,6 @@ rclone_includes(
 files of the Staging universe.}
 
 \item{repo_staging}{Character string, URL of the Staging universe.}
-
-\item{mock}{For testing purposes only, a named list of data frames
-for inputs to various intermediate functions.}
 }
 \description{
 Write text files to pass to the \code{--include-from} flag

--- a/man/rclone_includes.Rd
+++ b/man/rclone_includes.Rd
@@ -4,11 +4,7 @@
 \alias{rclone_includes}
 \title{Write Rclone includes.}
 \usage{
-rclone_includes(
-  path_staging,
-  repo_staging = "https://staging.r-multiverse.org",
-  mock = NULL
-)
+rclone_includes(path_staging)
 }
 \arguments{
 \item{path_staging}{Character string, directory path to the source
@@ -26,14 +22,8 @@ url_staging = "https://github.com/r-multiverse/staging"
 path_staging <- tempfile()
 path_community <- tempfile()
 gert::git_clone(url = url_staging, path = path_staging)
-stage_candidates(
-  path_staging = path_staging,
-  repo_staging = "https://staging.r-multiverse.org"
-)
-rclone_includes(
-  path_staging,
-  repo_staging = "https://staging.r-multiverse.org"
-)
+stage_candidates(path_staging = path_staging)
+rclone_includes(path_staging)
 }
 }
 \seealso{

--- a/man/stage_candidates.Rd
+++ b/man/stage_candidates.Rd
@@ -4,20 +4,11 @@
 \alias{stage_candidates}
 \title{Stage release candidates}
 \usage{
-stage_candidates(
-  path_staging,
-  repo_staging = "https://staging.r-multiverse.org",
-  mock = NULL
-)
+stage_candidates(path_staging)
 }
 \arguments{
 \item{path_staging}{Character string, directory path to the source
 files of the Staging universe.}
-
-\item{repo_staging}{Character string, URL of the Staging universe.}
-
-\item{mock}{For testing purposes only, a named list of data frames
-for inputs to various intermediate functions.}
 }
 \value{
 \code{NULL} (invisibly)

--- a/man/update_status.Rd
+++ b/man/update_status.Rd
@@ -26,9 +26,6 @@ to the clone of the Community universe GitHub repository.}
 \item{repo_staging}{Character string, URL of the staging universe.}
 
 \item{repo_community}{Character string, URL of the Community universe.}
-
-\item{mock}{For testing purposes only, a named list of data frames
-for inputs to various intermediate functions.}
 }
 \description{
 Update the repository which reports the status on individual

--- a/man/update_status.Rd
+++ b/man/update_status.Rd
@@ -4,14 +4,7 @@
 \alias{update_status}
 \title{Update the package status repository}
 \usage{
-update_status(
-  path_status,
-  path_staging,
-  path_community,
-  repo_staging = "https://staging.r-multiverse.org",
-  repo_community = "https://community.r-multiverse.org",
-  mock = NULL
-)
+update_status(path_status, path_staging, path_community)
 }
 \arguments{
 \item{path_status}{Character string, directory path to the source files
@@ -22,10 +15,6 @@ to the clone of the Staging universe GitHub repository.}
 
 \item{path_community}{Character string, local directory path
 to the clone of the Community universe GitHub repository.}
-
-\item{repo_staging}{Character string, URL of the staging universe.}
-
-\item{repo_community}{Character string, URL of the Community universe.}
 }
 \description{
 Update the repository which reports the status on individual
@@ -43,9 +32,7 @@ gert::git_clone(url = url_community, path = path_community)
 update_status(
   path_status = path_status,
   path_staging = path_staging,
-  path_community = path_community,
-  repo_staging = "https://staging.r-multiverse.org",
-  repo_community = "https://community.r-multiverse.org"
+  path_community = path_community
 )
 writeLines(
   readLines(

--- a/man/update_topics.Rd
+++ b/man/update_topics.Rd
@@ -11,9 +11,6 @@ update_topics(path, repo = "https://community.r-multiverse.org", mock = NULL)
 local file path to the topics repository source code.}
 
 \item{repo}{Character string, URL of the Community universe.}
-
-\item{mock}{For testing purposes only, a named list of data frames
-for inputs to various intermediate functions.}
 }
 \value{
 \code{NULL} (invisibly). Called for its side effects.

--- a/man/update_topics.Rd
+++ b/man/update_topics.Rd
@@ -11,6 +11,8 @@ update_topics(path, repo = "https://community.r-multiverse.org", mock = NULL)
 local file path to the topics repository source code.}
 
 \item{repo}{Character string, URL of the Community universe.}
+
+\item{mock}{List of named objects for testing purposes only.}
 }
 \value{
 \code{NULL} (invisibly). Called for its side effects.

--- a/tests/testthat/test-rclone_includes.R
+++ b/tests/testthat/test-rclone_includes.R
@@ -21,23 +21,12 @@ test_that("rclone_includes()", {
     function(x) x$package,
     FUN.VALUE = character(1L)
   )
-  meta_staging <- data.frame(
-    package = names_staging,
-    version = "1.2.3",
-    remotesha = paste0("sha-", names_staging)
-  )
-  stage_candidates(
-    path_staging = path_staging,
-    mock = list(staging = meta_staging)
-  )
+  stage_candidates(path_staging = path_staging)
   file_packages <- file.path(path_staging, "include-packages.txt")
   file_meta <- file.path(path_staging, "include-meta.txt")
   expect_false(file.exists(file_packages))
   expect_false(file.exists(file_meta))
-  rclone_includes(
-    path_staging,
-    mock = list(staging = meta_staging)
-  )
+  rclone_includes(path_staging)
   expect_true(file.exists(file_packages))
   expect_true(file.exists(file_meta))
   include_packages <- readLines(file_packages)
@@ -45,12 +34,12 @@ test_that("rclone_includes()", {
     sort(include_packages),
     sort(
       c(
-        "src/contrib/staged_1.2.3.tar.gz",
-        "src/contrib/removed-no-issue_1.2.3.tar.gz",
-        "bin/macosx/*/contrib/4.4/staged_1.2.3.tgz",
-        "bin/macosx/*/contrib/4.4/removed-no-issue_1.2.3.tgz",
-        "bin/windows/contrib/4.4/staged_1.2.3.zip",
-        "bin/windows/contrib/4.4/removed-no-issue_1.2.3.zip"
+        "src/contrib/staged_2.0.5.tar.gz",
+        "src/contrib/removed-no-issue_2.0.6.tar.gz",
+        "bin/macosx/*/contrib/4.4/staged_2.0.5.tgz",
+        "bin/macosx/*/contrib/4.4/removed-no-issue_2.0.6.tgz",
+        "bin/windows/contrib/4.4/staged_2.0.5.zip",
+        "bin/windows/contrib/4.4/removed-no-issue_2.0.6.zip"
       )
     )
   )

--- a/tests/testthat/test-stage_candidates.R
+++ b/tests/testthat/test-stage_candidates.R
@@ -17,15 +17,7 @@ test_that("stage_candidates()", {
   file_config <- file.path(path_staging, "config.json")
   file_staging <- file.path(path_staging, "packages.json")
   json_staging <- jsonlite::read_json(file_staging, simplifyVector = TRUE)
-  meta_staging <- data.frame(
-    package = json_staging$package,
-    version = "1.2.3",
-    remotesha = paste0("sha-", json_staging$package)
-  )
-  stage_candidates(
-    path_staging = path_staging,
-    mock = list(staging = meta_staging)
-  )
+  stage_candidates(path_staging = path_staging)
   config <- jsonlite::read_json(file_config, simplifyVector = TRUE)
   expect_equal(names(config), "cran_version")
   expect_true(is.character(config$cran_version))
@@ -56,10 +48,7 @@ test_that("stage_candidates()", {
   json_issues <- jsonlite::read_json(file_issues, simplifyVector = TRUE)
   json_issues$staged <- json_issues$issue
   jsonlite::write_json(json_issues, file_issues, pretty = TRUE)
-  stage_candidates(
-    path_staging = path_staging,
-    mock = list(staging = meta_staging)
-  )
+  stage_candidates(path_staging = path_staging)
   packages <- jsonlite::read_json(file_staging, simplifyVector = TRUE)
   package <- c("issue", "removed-has-issue", "removed-no-issue", "staged")
   expect_equal(
@@ -73,12 +62,11 @@ test_that("stage_candidates()", {
   # Broken package gets fixed.
   file_issues <- file.path(path_staging, "issues.json")
   json_issues <- jsonlite::read_json(file_issues, simplifyVector = TRUE)
+  hash <- json_issues$issue$remote_hash
   json_issues$issue <- json_issues[["removed-no-issue"]]
+  json_issues$issue$remote_hash <- hash
   jsonlite::write_json(json_issues, file_issues, pretty = TRUE)
-  stage_candidates(
-    path_staging = path_staging,
-    mock = list(staging = meta_staging)
-  )
+  stage_candidates(path_staging = path_staging)
   packages <- jsonlite::read_json(file_staging, simplifyVector = TRUE)
   package <- c("issue", "removed-has-issue", "removed-no-issue", "staged")
   expect_equal(

--- a/tests/testthat/test-update_status.R
+++ b/tests/testthat/test-update_status.R
@@ -138,7 +138,7 @@ test_that("update_status()", {
       )
     )
   )
-   expect_equal(
+  expect_equal(
     sort(list.files(out_community)),
     sort(
       c(

--- a/tests/testthat/test-update_status.R
+++ b/tests/testthat/test-update_status.R
@@ -24,37 +24,15 @@ test_that("update_status()", {
   )
   file_staging <- file.path(path_staging, "packages.json")
   file_community <- file.path(path_community, "packages.json")
-  json_staging <- jsonlite::read_json(file_staging)
-  json_community <- jsonlite::read_json(file_community)
-  names_staging <- vapply(
-    json_staging,
-    function(x) x$package,
-    FUN.VALUE = character(1L)
-  )
-  names_community <- vapply(
-    json_community,
-    function(x) x$package,
-    FUN.VALUE = character(1L)
-  )
-  meta_staging <- data.frame(
-    package = names_staging,
-    remotesha = paste0("sha-", names_staging)
-  )
-  meta_community <- data.frame(
-    package = names_community,
-    remotesha = paste0("sha-", names_community)
-  )
+  json_staging <- jsonlite::read_json(file_staging, simplifyVector = TRUE)
+  json_community <- jsonlite::read_json(file_community, simplifyVector = TRUE)
   path_status <- tempfile()
   on.exit(unlink(path_status, recursive = TRUE), add = TRUE)
-  stage_candidates(
-    path_staging = path_staging,
-    mock = list(staging = meta_staging)
-  )
+  stage_candidates(path_staging = path_staging)
   update_status(
     path_status = path_status,
     path_staging = path_staging,
-    path_community = path_community,
-    mock = list(staging = meta_staging, community = meta_community)
+    path_community = path_community
   )
   expect_true(
     all(
@@ -82,8 +60,8 @@ test_that("update_status()", {
     sort(list.files(out_staging)),
     sort(
       c(
-        paste0(names_staging, ".html"),
-        paste0(names_staging, ".xml")
+        paste0(json_staging$package, ".html"),
+        paste0(json_staging$package, ".xml")
       )
     )
   )
@@ -91,8 +69,8 @@ test_that("update_status()", {
     sort(list.files(out_community)),
     sort(
       c(
-        paste0(names_community, ".html"),
-        paste0(names_community, ".xml")
+        paste0(json_community$package, ".html"),
+        paste0(json_community$package, ".xml")
       )
     )
   )
@@ -149,15 +127,24 @@ test_that("update_status()", {
   update_status(
     path_status = path_status,
     path_staging = path_staging,
-    path_community = path_community,
-    mock = list(staging = meta_staging[1L, ], community = meta_community[1L, ])
+    path_community = path_community
   )
   expect_equal(
     sort(list.files(out_staging)),
-    sort(paste0(meta_staging[1L, "package"], c(".html", ".xml")))
+    sort(
+      c(
+        paste0(json_staging$package, ".html"),
+        paste0(json_staging$package, ".xml")
+      )
+    )
   )
-  expect_equal(
+   expect_equal(
     sort(list.files(out_community)),
-    sort(sort(paste0(meta_community[1L, "package"], c(".html", ".xml"))))
+    sort(
+      c(
+        paste0(json_community$package, ".html"),
+        paste0(json_community$package, ".xml")
+      )
+    )
   )
 })


### PR DESCRIPTION
Simplify `stage_candidates()`, `rclone_includes()`, and `update_status()`: get remote hashes from pre-recorded `issues.json`, as opposed to a separate call to `meta_packages()`. This ensures those remote hashes are more contemporaneous with the corresponding reported check results.