### PR TITLE
Fix date/time reporting in status

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal infrastructure package to
   automate contribution reviews and populate universes.
-Version: 1.0.5
+Version: 1.0.6
 License: MIT + file LICENSE
 URL:
   https://r-multiverse.org/multiverse.internals/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# multiverse.internals 1.0.6
+
+* Report the date last published on R-universe.
+
 # multiverse.internals 1.0.5
 
 * Revamp topics website.

--- a/R/interpret_status.R
+++ b/R/interpret_status.R
@@ -47,8 +47,8 @@ interpret_success <- function(status, package) {
   }
   paste0(
     out,
-    " (last updated on ",
-    status$date,
+    " (last published at ",
+    status$published,
     ")."
   )
 }
@@ -64,7 +64,7 @@ interpret_title <- function(status, package) {
   if (is.character(status$remote_hash)) {
     title <- paste(title, "remote hash", status$remote_hash)
   }
-  paste0(title, " (last updated on ", status$date, ").<br><br>")
+  paste0(title, " (last published at ", status$published, ").<br><br>")
 }
 
 interpret_advisories <- function(status) {

--- a/R/meta_packages.R
+++ b/R/meta_packages.R
@@ -21,7 +21,7 @@
 #' meta_packages(repo = "https://wlandau.r-universe.dev")
 meta_packages <- function(
   repo = "https://community.r-multiverse.org",
-  fields = c("Version", "License", "Remotes", "RemoteSha")
+  fields = c("Version", "License", "Remotes", "RemoteSha", "_published")
 ) {
   repo <- trim_url(repo)
   listing <- file.path(
@@ -36,6 +36,7 @@ meta_packages <- function(
     simplifyMatrix = TRUE
   )
   colnames(out) <- tolower(colnames(out))
+  colnames(out) <- gsub("^_", "", colnames(out))
   rownames(out) <- out$package
   foss <- utils::available.packages(repos = repo, filters = "license/FOSS")
   out$foss <- FALSE

--- a/R/meta_packages.R
+++ b/R/meta_packages.R
@@ -38,6 +38,7 @@ meta_packages <- function(
   colnames(out) <- tolower(colnames(out))
   colnames(out) <- gsub("^_", "", colnames(out))
   rownames(out) <- out$package
+  out$published <- format_time_stamp(out$published)
   foss <- utils::available.packages(repos = repo, filters = "license/FOSS")
   out$foss <- FALSE
   out[as.character(foss[, "Package"]), "foss"] <- TRUE
@@ -48,4 +49,9 @@ meta_packages <- function(
   )
   out <- merge(x = out, y = cran, all.x = TRUE, all.y = FALSE)
   out
+}
+
+format_time_stamp <- function(time) {
+  time <- as.POSIXct(time, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC")
+  format(time, format = "%Y-%m-%d %H:%M:%OS3 %Z")
 }

--- a/R/status_dependencies.R
+++ b/R/status_dependencies.R
@@ -70,7 +70,7 @@ status_dependencies <- function(
 
 status_dependencies_graph <- function(meta) {
   repo_packages <- meta$package
-  repo_dependencies <- meta[["_dependencies"]]
+  repo_dependencies <- meta$dependencies
   from <- list()
   to <- list()
   for (index in seq_len(nrow(meta))) {

--- a/R/update_status.R
+++ b/R/update_status.R
@@ -172,9 +172,9 @@ status_rows <- function(status) {
     \(x) as.character(x$version),
     FUN.VALUE = character(1L)
   )
-  date <- vapply(
+  published <- vapply(
     status,
-    \(x) as.character(x$date),
+    \(x) as.character(x$published),
     FUN.VALUE = character(1L)
   )
   url <- sprintf(
@@ -184,7 +184,7 @@ status_rows <- function(status) {
   )
   out <- paste0(
     "|",
-    paste(url, version, date, sep = "|"),
+    paste(url, version, published, sep = "|"),
     "|"
   )
   paste(out, collapse = "\n")

--- a/inst/mock/community/status.json
+++ b/inst/mock/community/status.json
@@ -9,19 +9,19 @@
       "_buildurl": ["https://github.com/r-universe/r-multiverse/actions/runs/12345"]
     },
     "success": [false],
-    "date": ["1980-01-01"],
+    "published": ["1980-01-01"],
     "version": ["2.0.1"],
     "remote_hash": ["sha-issue"]
   },
   "add": {
     "success": [true],
-    "date": ["1980-01-01"],
+    "published": ["1980-01-01"],
     "version": ["2.0.2"],
     "remote_hash": ["sha-add"]
   },
   "staged": {
     "success": [true],
-    "date": ["1980-01-01"],
+    "published": ["1980-01-01"],
     "version": ["2.0.3"],
     "remote_hash": ["sha-staged"]
   }

--- a/inst/mock/staging/status.json
+++ b/inst/mock/staging/status.json
@@ -9,7 +9,7 @@
       "_buildurl": ["https://github.com/r-universe/r-multiverse/actions/runs/12345"]
     },
     "success": [false],
-    "date": ["1980-01-01"],
+    "published": ["1980-01-01"],
     "version": ["2.0.3"],
     "remote_hash": ["sha-issue"]
   },
@@ -23,19 +23,19 @@
       "_buildurl": ["https://github.com/r-universe/r-multiverse/actions/runs/12345"]
     },
     "success": [false],
-    "date": ["1980-01-01"],
+    "published": ["1980-01-01"],
     "version": ["2.0.4"],
     "remote_hash": ["sha-removed-has-issue"]
   },
   "staged": {
     "success": [true],
-    "date": ["1980-01-01"],
+    "published": ["1980-01-01"],
     "version": ["2.0.5"],
     "remote_hash": ["sha-staged"]
   },
   "removed-no-issue": {
     "success": [true],
-    "date": ["1980-01-01"],
+    "published": ["1980-01-01"],
     "version": ["2.0.6"],
     "remote_hash": ["sha-removed-no-issue"]
   }

--- a/man/meta_packages.Rd
+++ b/man/meta_packages.Rd
@@ -6,7 +6,7 @@
 \usage{
 meta_packages(
   repo = "https://community.r-multiverse.org",
-  fields = c("Version", "License", "Remotes", "RemoteSha")
+  fields = c("Version", "License", "Remotes", "RemoteSha", "_published")
 )
 }
 \arguments{

--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -165,6 +165,7 @@ mock_meta_checks <- structure(
 # dput(meta_packages(repo = "https://community.r-multiverse.org")) # nolint
 mock_meta_packages <- structure(
   list(
+    "published" = paste0("published_", seq_len(20L)),
     "_id" = c(
       "6662a46b4e86770016655c87", "6662991c4e867700166503e4",
       "66629ac44e86770016650d77", "66622a203f30cb0016a5dc6d",
@@ -653,6 +654,7 @@ mock_meta_packages <- structure(
 # dput(meta_packages(repo = "https://wlandau.r-universe.dev")) # nolint
 mock_meta_packages_graph <- structure(
   list(
+    published = paste0("published_", seq_len(5L)),
     "_id" = c(
       "666319a14e86770016661a28", "66580c6dd014ca0014e5afc2",
       "665179088d83a20014a4037a", "6666d6575e691000165322b1",

--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -166,7 +166,7 @@ mock_meta_checks <- structure(
 mock_meta_packages <- structure(
   list(
     "published" = paste0("published_", seq_len(20L)),
-    "_id" = c(
+    "id" = c(
       "6662a46b4e86770016655c87", "6662991c4e867700166503e4",
       "66629ac44e86770016650d77", "66622a203f30cb0016a5dc6d",
       "6662a8364e86770016656250",
@@ -242,12 +242,12 @@ mock_meta_packages <- structure(
       "3f18e78dffa3e45863e95aeb683aa08b", "7e8e297f00058b895d75201f31e65812",
       "31c8eed8564835a1d83b8115c71dfdf4"
     ),
-    "_type" = c(
+    "type" = c(
       "src", "src",
       "src", "src", "src", "src", "src", "src", "src", "src", "src",
       "src", "src", "src", "src", "src", "src", "src", "src", "src"
     ),
-    "_dependencies" = list(
+    "dependencies" = list(
       structure(
         list(
           package = c(
@@ -686,8 +686,8 @@ mock_meta_packages_graph <- structure(
       "3c92053c75031ec0b976b0a15185e3a0",
       "1507b3a27da7dff5d9acbf8ef181ad78"
     ),
-    "_type" = c("src", "src", "src", "src", "src"),
-    "_dependencies" = list(
+    "type" = c("src", "src", "src", "src", "src"),
+    "dependencies" = list(
       structure(
         list(
           package = c(

--- a/tests/testthat/test-interpret_status.R
+++ b/tests/testthat/test-interpret_status.R
@@ -183,8 +183,7 @@ test_that("interpret_status() with complicated dependency problems", {
       versions = versions,
       mock = list(
         checks = meta_checks,
-        packages = mock_meta_packages_graph,
-        today = "2024-01-01"
+        packages = mock_meta_packages_graph
       ),
       output = output,
       verbose = TRUE
@@ -202,7 +201,7 @@ test_that("interpret_status() with complicated dependency problems", {
         hash_highest = "hash_1.0.0"
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_5",
       version = "1.1.0.9000",
       remote_hash = "85dd672a44a92c890eb40ea9ebab7a4e95335c2f"
     )
@@ -214,7 +213,7 @@ test_that("interpret_status() with complicated dependency problems", {
         nanonext = list()
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_4",
       version = "1.1.0.9000",
       remote_hash = "7015695b7ef82f82ab3225ac2d226b2c8f298097"
     )
@@ -235,7 +234,7 @@ test_that("interpret_status() with complicated dependency problems", {
       ),
       dependencies = list(nanonext = "mirai"),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_1",
       version = "0.9.3.9002",
       remote_hash = "eafad0276c06dec2344da2f03596178c754c8b5e"
     )

--- a/tests/testthat/test-interpret_status.R
+++ b/tests/testthat/test-interpret_status.R
@@ -13,14 +13,14 @@ test_that("interpret_status() with a successful package", {
         abc = list(
           success = TRUE,
           version = "v",
-          date = "d",
+          published = "d",
           remote_hash = "h"
         )
       )
     ),
     paste(
       "R-multiverse checks passed for package abc version v remote",
-      "hash h (last updated on d)."
+      "hash h (last published at d)."
     )
   )
 })

--- a/tests/testthat/test-meta_checks.R
+++ b/tests/testthat/test-meta_checks.R
@@ -11,7 +11,7 @@ test_that("meta_checks_process_json() with a source failure", {
     list(
       Package = c("mirai", "crew"),
       "_user" = c("r-multiverse-staging", "r-multiverse-staging"),
-      "_type" = c("src", "src"),
+      "_type" = c("src", "failure"),
       "_commit" = structure(
         list(
           id = c(
@@ -27,6 +27,9 @@ test_that("meta_checks_process_json() with a source failure", {
         "https://github.com/r-universe/r-multiverse-staging/buildurl",
         "https://github.com/r-universe/r-multiverse-staging/buildurl"
       ),
+      "_published" = c("date1", "date2"),
+      "RemoteSha" = c("sha1", "sha2"),
+      "Version" = c("version1", "version2"),
       "_indexed" = c(FALSE, FALSE),
       "_binaries" = list(
         structure(
@@ -129,7 +132,8 @@ test_that("meta_checks_process_json() with a source failure", {
           buildurl = c(
             NA,
             "https://github.com/r-universe/r-multiverse-staging/failure"
-          )
+          ),
+          version = c(NA, "version_failed")
         ),
         row.names = c(6L, 13L),
         class = "data.frame"

--- a/tests/testthat/test-record_status.R
+++ b/tests/testthat/test-record_status.R
@@ -42,7 +42,7 @@ test_that("record_status() mocked", {
         )
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = NA,
       version = NA,
       remote_hash = NA
     )
@@ -62,7 +62,7 @@ test_that("record_status() mocked", {
         remotes = c("hyunjimoon/SBC", "stan-dev/cmdstanr")
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_14",
       version = "0.1.1",
       remote_hash = "bbdda1b4a44a3d6a22041e03eed38f27319d8f32"
     )
@@ -74,7 +74,7 @@ test_that("record_status() mocked", {
         license = "non-standard"
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_16",
       version = "0.0.1",
       remote_hash = "a199a734b16f91726698a19e5f147f57f79cb2b6"
     )
@@ -89,7 +89,7 @@ test_that("record_status() mocked", {
         hash_highest = "hash_1.0.0"
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = NA,
       version = NA,
       remote_hash = NA
     )
@@ -104,71 +104,11 @@ test_that("record_status() mocked", {
         hash_highest = "hash_1.0.0"
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = NA,
       version = NA,
       remote_hash = NA
     )
   )
-})
-
-test_that("record_status() date works", {
-  output <- tempfile()
-  record_status(
-    versions = mock_versions(),
-    mock = list(
-      checks = mock_meta_checks,
-      packages = mock_meta_packages,
-      today = "2024-01-01"
-    ),
-    output = output,
-    verbose = FALSE
-  )
-  record_status(
-    versions = mock_versions(),
-    mock = list(
-      checks = mock_meta_checks,
-      packages = mock_meta_packages
-    ),
-    output = output,
-    verbose = FALSE
-  )
-  status <- jsonlite::read_json(output, simplifyVector = TRUE)
-  for (package in names(status)) {
-    expect_equal(status[[package]]$date, "2024-01-01")
-  }
-  never_fixed <- c(
-    "INLA",
-    "stantargets",
-    "tidytensor",
-    "version_decremented"
-  )
-  once_fixed <- c(
-    "audio.whisper",
-    "SBC",
-    "tidypolars",
-    "version_unmodified"
-  )
-  for (package in once_fixed) {
-    status[[package]] <- NULL
-  }
-  jsonlite::write_json(x = status, path = output, pretty = TRUE)
-  record_status(
-    versions = mock_versions(),
-    mock = list(
-      checks = mock_meta_checks,
-      packages = mock_meta_packages
-    ),
-    output = output,
-    verbose = FALSE
-  )
-  status <- jsonlite::read_json(output, simplifyVector = TRUE)
-  for (package in never_fixed) {
-    expect_equal(status[[package]]$date, "2024-01-01")
-  }
-  today <- format(Sys.Date(), fmt = "yyyy-mm-dd")
-  for (package in once_fixed) {
-    expect_equal(status[[package]]$date, today)
-  }
 })
 
 test_that("record_status() on a small repo", {
@@ -229,7 +169,7 @@ test_that("record_status() with dependency problems", {
         hash_highest = "hash_1.0.0"
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_5",
       version = "1.1.0.9000",
       remote_hash = "85dd672a44a92c890eb40ea9ebab7a4e95335c2f"
     )
@@ -241,7 +181,7 @@ test_that("record_status() with dependency problems", {
         nanonext = list()
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_4",
       version = "1.1.0.9000",
       remote_hash = "7015695b7ef82f82ab3225ac2d226b2c8f298097"
     )
@@ -254,7 +194,7 @@ test_that("record_status() with dependency problems", {
         nanonext = "mirai"
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_1",
       version = "0.9.3.9002",
       remote_hash = "eafad0276c06dec2344da2f03596178c754c8b5e"
     )
@@ -267,7 +207,7 @@ test_that("record_status() with dependency problems", {
         nanonext = "crew"
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_2",
       version = "0.0.5.9000",
       remote_hash = "4d9e5b44e2942d119af963339c48d134e84de458"
     )
@@ -280,7 +220,7 @@ test_that("record_status() with dependency problems", {
         nanonext = "crew"
       ),
       success = FALSE,
-      date = "2024-01-01",
+      published = "published_3",
       version = "0.3.1",
       remote_hash = "d4ac61fd9a1d9539088ffebdadcd4bb713c25ee1"
     )

--- a/tests/testthat/test-status_dependencies.R
+++ b/tests/testthat/test-status_dependencies.R
@@ -115,8 +115,8 @@ test_that("status_dependencies() with more than one direct dependency", {
   row <- meta[meta$package == "crew", ]
   row$package <- "x"
   meta <- rbind(meta, row)
-  meta[["_dependencies"]][meta$package == "crew.aws.batch"][[1L]] <- rbind(
-    meta[["_dependencies"]][meta$package == "crew.aws.batch"][[1L]],
+  meta[["dependencies"]][meta$package == "crew.aws.batch"][[1L]] <- rbind(
+    meta[["dependencies"]][meta$package == "crew.aws.batch"][[1L]],
     data.frame(package = "x", version = NA_character_, role = "Imports")
   )
   expect_equal(
@@ -135,8 +135,8 @@ test_that("status_dependencies() with more than one direct dependency (2)", {
   row <- meta[meta$package == "crew", ]
   row$package <- "x"
   meta <- rbind(meta, row)
-  meta[["_dependencies"]][meta$package == "crew.aws.batch"][[1L]] <- rbind(
-    meta[["_dependencies"]][meta$package == "crew.aws.batch"][[1L]],
+  meta[["dependencies"]][meta$package == "crew.aws.batch"][[1L]] <- rbind(
+    meta[["dependencies"]][meta$package == "crew.aws.batch"][[1L]],
     data.frame(package = "x", version = NA_character_, role = "Imports")
   )
   expect_equal(


### PR DESCRIPTION
This PR pulls from the `_published` field on R-universe to get time stamps for package status.