### PR TITLE
fix FOSS license detection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: multiverse.internals
 Title: Internal Infrastructure for R-multiverse
 Description: R-multiverse requires this internal infrastructure package to
   automate contribution reviews and populate universes.
-Version: 1.0.10
+Version: 1.0.11
 License: MIT + file LICENSE
 URL:
   https://r-multiverse.org/multiverse.internals/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# multiverse.internals 1.0.11
+
+* Use `tools::analyze_license()` for continuous license checks because `utils::available.packages(repos = "https://community.r-multiverse.org", filters = "license/FOSS")` no longer returns output.
+* Strengthen continuous license checks: an `NA` license (from a failed source build) is no longer acceptable.
+
 # multiverse.internals 1.0.10
 
 * Allow `review_pull_request()` to get advisories and organizations if not supplied.

--- a/R/assert_package_description.R
+++ b/R/assert_package_description.R
@@ -107,10 +107,7 @@ assert_parsed_description <- function(name, description) {
     )
   }
   license <- description$get("License")
-  license_data <- tools::analyze_license(license)
-  license_okay <- isTRUE(license_data$is_canonical) &&
-    (isTRUE(license_data$is_FOSS) || isTRUE(license_data$is_verified))
-  if (!license_okay) {
+  if (!all(license_okay(license))) {
     return(
       paste(
         "Detected license",

--- a/R/issues_licenses.R
+++ b/R/issues_licenses.R
@@ -9,6 +9,6 @@
 #' issues_licenses()
 #' }
 issues_licenses <- function(meta = meta_packages()) {
-  meta$foss[is.na(meta$foss)] <- TRUE
+  meta$foss[is.na(meta$foss)] <- FALSE # deliberately redundant
   meta[!meta$foss, c("package", "license"), drop = FALSE]
 }

--- a/R/utils_license.R
+++ b/R/utils_license.R
@@ -1,0 +1,9 @@
+license_okay <- Vectorize(
+  function(license) {
+    license_data <- tools::analyze_license(license)
+    isTRUE(license_data$is_canonical) &&
+      (isTRUE(license_data$is_FOSS) || isTRUE(license_data$is_verified))
+  },
+  "license",
+  USE.NAMES = FALSE
+)

--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -928,7 +928,7 @@ mock_meta_packages <- structure(list(
     "MIT + file LICENSE", "MIT + file LICENSE", "MIT + file LICENSE",
     "MIT + file LICENSE", "MIT + file LICENSE", "MIT + file LICENSE",
     "AGPL-3", "MIT + file LICENSE", "GPL (>= 2)", "GPL (>= 3)",
-    "GPL (>= 2)", "MIT + file LICENSE", NA, "MIT + file LICENSE",
+    "GPL (>= 2)", "MIT + file LICENSE", "NOT FOUND", "MIT + file LICENSE",
     "MIT + file LICENSE", "MIT + file LICENSE", "MIT + file LICENSE",
     "MIT + file LICENSE", "GPL (>= 3)", "MIT + file LICENSE",
     "MIT + file LICENSE", "Apache License (>= 2)", "GPL (>= 3)",
@@ -1063,7 +1063,7 @@ mock_meta_packages <- structure(list(
     TRUE, TRUE, TRUE, TRUE,
     TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
     TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
-    NA, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
+    FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
     TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
     TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE
   ), cran = c(
@@ -1228,6 +1228,7 @@ mock_status <- list(
     success = FALSE,
     published = "2025-03-06 02:51:02.348 UTC", version = "19.09.03",
     remote_hash = "0fa332471d2e19548cc0f63e36873e31dbd685be",
+    license = "NOT FOUND",
     r_cmd_check = list(issues = list(
       linux = "MISSING", mac = "MISSING",
       win = "MISSING", source = "FAILURE"


### PR DESCRIPTION
FOSS license detection somehow broke because `utils::available.packages(repos = "https://community.r-multiverse.org", filters = "license/FOSS")` no longer produces output (c.f. https://github.com/r-multiverse/help/issues/158#issuecomment-2892579485). This PR implements a workaround and makes license detection more robust in general.