### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/air.yaml
+++ b/.github/workflows/air.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main, master]
 
 name: air
+permissions:
+  contents: read
 
 jobs:
   air:


### PR DESCRIPTION
Potential fix for [https://github.com/r-multiverse/multiverse.internals/security/code-scanning/3](https://github.com/r-multiverse/multiverse.internals/security/code-scanning/3)

To fix this issue, you should add a `permissions` block to the workflow file `.github/workflows/air.yaml` at the root level (before the `jobs` section). Set the permissions for the GITHUB_TOKEN to the minimal required privileges, typically `contents: read` for workflows that merely check out code, install dependencies, and run formatting checks. This change restricts the token to only read the repository contents, following the least privilege principle without breaking the functionality of the current workflow. No additional imports or complex changes are necessary; it is a straightforward update to the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
